### PR TITLE
Add Azure deployment script and bicep template

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Set default location
+location="eastus2"
+
+# Check for the existence of the resource group, create if not exists
+resourceGroupName="myResourceGroup"
+if ! az group exists --name $resourceGroupName; then
+  echo "Creating resource group: $resourceGroupName"
+  az group create --name $resourceGroupName --location $location
+else
+  echo "Resource group $resourceGroupName already exists."
+fi
+
+# Deploy resources using Bicep file
+echo "Deploying resources to $resourceGroupName in $location..."
+az deployment group create --resource-group $resourceGroupName --template-file infra/main.bicep --parameters location=$location
+
+# Check for the existence of the storage account, create if not exists
+storageAccountName="mystorageaccount"
+if ! az storage account check-name --name $storageAccountName --query 'nameAvailable'; then
+  echo "Creating storage account: $storageAccountName"
+  az storage account create --name $storageAccountName --resource-group $resourceGroupName --location $location --sku Standard_LRS
+else
+  echo "Storage account $storageAccountName already exists."
+fi
+
+# Upload contents of /src to the Azure blob storage
+echo "Uploading contents of /src to $storageAccountName..."
+az storage blob upload-batch --account-name $storageAccountName --source src --destination \$web

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,19 @@
+// Define Azure resources for deployment
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: 'mystorageaccount'
+  location: 'eastus2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    supportsHttpsTrafficOnly: true
+    accessTier: 'Hot'
+  }
+}
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
+  name: 'myResourceGroup'
+  location: 'eastus2'
+}


### PR DESCRIPTION
Related to #1

Adds a deployment script and Bicep template to enable deploying contents of `/src` to Azure blob storage, including the creation of necessary Azure resources.

- **Script Implementation**: Implements `infra/deploy.sh` to handle deployment logistics. This script checks for the existence of a resource group and storage account, creating them if they do not exist. It sets the deployment region to US East 2, deploys resources using a Bicep file, and uploads the contents of `/src` to Azure blob storage.
- **Bicep Template**: Adds `infra/main.bicep` to define the Azure resources required for deployment. This includes the specification for a storage account and a resource group, both set to be located in US East 2.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/doingwebdev/blob-deploy/issues/1?shareId=6ce5b7ea-c213-4df7-b1a4-4344c8ff3f74).